### PR TITLE
fix: clear schedule on update when schedule block is removed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/stretchr/testify v1.11.1
-	github.com/winebarrel/redash-go/v2 v2.9.0
+	github.com/winebarrel/redash-go/v2 v2.10.0
 )
 
 require (
@@ -26,7 +26,6 @@ require (
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.18.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,6 @@ github.com/go-git/go-billy/v5 v5.8.0 h1:I8hjc3LbBlXTtVuFNJuwYuMiHvQJDq1AT6u4DwDz
 github.com/go-git/go-billy/v5 v5.8.0/go.mod h1:RpvI/rw4Vr5QA+Z60c6d6LXH0rYJo0uD5SqfmrrheCY=
 github.com/go-git/go-git/v5 v5.18.0 h1:O831KI+0PR51hM2kep6T8k+w0/LIAD490gvqMCvL5hM=
 github.com/go-git/go-git/v5 v5.18.0/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
-github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
-github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -204,8 +202,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/winebarrel/redash-go/v2 v2.9.0 h1:9rS31rJn7041ojWWMH0amxXTI6xj8A9LnrprT/hCgXg=
-github.com/winebarrel/redash-go/v2 v2.9.0/go.mod h1:9ONjeFWnlxT+b9ZOQw0+gG4lVK5yHJR0rnFLlQZ833Q=
+github.com/winebarrel/redash-go/v2 v2.10.0 h1:e3PFx+6G/cmBj7qwpY2gsDaZ231radI4Pj7wm/rOTkM=
+github.com/winebarrel/redash-go/v2 v2.10.0/go.mod h1:9ONjeFWnlxT+b9ZOQw0+gG4lVK5yHJR0rnFLlQZ833Q=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/redash/resource_query.go
+++ b/redash/resource_query.go
@@ -430,11 +430,12 @@ func updateQuery(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 	isDraft := !d.Get("published").(bool)
 
 	input := &redashgo.UpdateQueryInput{
-		DataSourceID: d.Get("data_source_id").(int),
-		Name:         d.Get("name").(string),
-		Description:  d.Get("description").(string),
-		Query:        d.Get("query").(string),
-		IsDraft:      &isDraft,
+		DataSourceID:            d.Get("data_source_id").(int),
+		Name:                    d.Get("name").(string),
+		Description:             d.Get("description").(string),
+		Query:                   d.Get("query").(string),
+		IsDraft:                 &isDraft,
+		WithoutOmittingSchedule: true,
 	}
 
 	schedules := d.Get("schedule").([]any)

--- a/redash/tests/resource_query_test.go
+++ b/redash/tests/resource_query_test.go
@@ -50,6 +50,14 @@ func TestAccQuery_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccQueryConfigBasic3,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckTypeSetElemNestedAttrs("redash_query.my_query", "schedule.*", map[string]string{
+						"interval": "1200",
+					}),
+				),
+			},
+			{
 				Config: testAccQueryConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("redash_query.my_query", "name", "my-query"),
@@ -58,6 +66,14 @@ func TestAccQuery_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr("redash_query.my_query", "interval"),
 					resource.TestCheckNoResourceAttr("redash_query.my_query", "tags"),
 					resource.TestCheckResourceAttr("redash_query.my_query", "schedule.#", "0"),
+				),
+			},
+			{
+				Config: testAccQueryConfigBasic2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckTypeSetElemNestedAttrs("redash_query.my_query", "schedule.*", map[string]string{
+						"interval": "600",
+					}),
 				),
 			},
 			{
@@ -136,6 +152,18 @@ resource "redash_query" "my_query" {
 	query          = "select 2"
 	schedule {
 		interval = 600
+	}
+}
+`
+
+const testAccQueryConfigBasic3 = testAccDataSourceConfigBasicPg + `
+resource "redash_query" "my_query" {
+	data_source_id = redash_data_source.my_data_source.id
+	name           = "my-query2"
+	description    = "my-query desc2"
+	query          = "select 2"
+	schedule {
+		interval = 1200
 	}
 }
 `


### PR DESCRIPTION
After #149, omitting `schedule` from the update payload makes Redash
keep the existing schedule untouched (Redash's `update_model` only
`setattr`s keys present in the request), so a query that previously
had `schedule { interval = N }` cannot be reverted to no schedule
from Terraform.

Use the `WithoutOmittingSchedule` flag added in redash-go v2.10.0 to
always emit the `schedule` field on update. When the schedule block
is absent in HCL, `Schedule` stays nil and is serialized as
`"schedule": null`, which Redash stores as JSON null and then excludes
from `outdated_queries` via the `jsonb_typeof != 'null'` filter.